### PR TITLE
Fix single pdfs view styling on mWeb

### DIFF
--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -251,7 +251,7 @@ function PDFPreviewer({
                             itemCount={numPages}
                             itemSize={calculatePageHeight}
                             estimatedItemSize={calculatePageHeight(0)}
-                            itemData={{pageWidth, estimatedPageHeight, calculatePageHeight, getDevicePixelRatio}}
+                            itemData={{pageWidth, estimatedPageHeight, calculatePageHeight, getDevicePixelRatio, containerHeight, numPages}}
                         >
                             {PageRenderer}
                         </List>

--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -12,6 +12,8 @@ type Props = {
         estimatedPageHeight: number;
         calculatePageHeight: (pageIndex: number) => number;
         getDevicePixelRatio: (width: number, height: number) => number | undefined;
+        numPages: number;
+        containerHeight: number;
     };
 };
 
@@ -29,6 +31,10 @@ const propTypes = {
         calculatePageHeight: PropTypes.func.isRequired,
         /** Function that calculates the pixel ratio for a page given its calculated width and height */
         getDevicePixelRatio: PropTypes.func.isRequired,
+        /** The number of pages in the document */
+        numPages: PropTypes.number.isRequired,
+        /** The height of the container view */
+        containerHeight: PropTypes.number.isRequired,
     }).isRequired,
 
     /** Additional style props passed by VariableSizeList */
@@ -37,16 +43,16 @@ const propTypes = {
 };
 
 function PageRenderer({index, style, data}: Props) {
-    const {pageWidth, estimatedPageHeight, calculatePageHeight, getDevicePixelRatio} = data;
+    const {pageWidth, estimatedPageHeight, calculatePageHeight, getDevicePixelRatio, numPages, containerHeight} = data;
     /**
      * Render a specific page based on its index.
      * The method includes a wrapper to apply virtualized styles.
      */
     const pageHeight = calculatePageHeight(index);
     const devicePixelRatio = getDevicePixelRatio(pageWidth, pageHeight);
-
+    const topPadding = numPages > 1 ? parseFloat(style.top as unknown as string) + PAGE_BORDER : containerHeight - parseFloat(style.height as unknown as string) / 2;
     return (
-        <div style={{...styles.pageWrapper, ...style, top: `${parseFloat(style.top as unknown as string) + PAGE_BORDER}px`}}>
+        <div style={{...styles.pageWrapper, ...style, top: `${topPadding}px`}}>
             <Page
                 key={`page_${index}`}
                 width={pageWidth}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/37724

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Upload a single-page pdf.
2. Tap on the PDF preview to open it.
3. Verify it is displayed centered in the middle in mobile view. 


### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

Referenced PR: https://github.com/Expensify/App/pull/38883