### PR TITLE
Fix scrolling with keyboard after viewing the PDF

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,6 +41,7 @@ const isSafari = () => getBrowser() === 'safari' || isMobileSafari();
 
 type ListRef = {
     tabIndex: number;
+    focus: () => void;
 };
 
 /**
@@ -58,6 +59,7 @@ const setListAttributes = (ref: ListRef | undefined) => {
      */
     // eslint-disable-next-line no-param-reassign
     ref.tabIndex = -1;
+    ref.focus();
 };
 
 export {getBrowser, isMobileSafari, isSafari, setListAttributes};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->
Enabling the user to scroll with the down key using the keyboard after viewing the pdf

### Related Issues


<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/34816#issuecomment-1900912907


### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Upload a PDF
2. Open it
3. Press the "down arrow" keyboard button
4. verify that the scroll is working.

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->


### Screenshots:

https://github.com/Expensify/react-fast-pdf/assets/59809993/8e673d17-19fb-42da-afbe-8f86dccafc9c


https://github.com/Expensify/react-fast-pdf/assets/59809993/0e70dfcb-b1cb-4b32-a6e2-30d5571592a6




