### PR TITLE
Fix negative top padding in single pdfs

### DIFF
--- a/src/PageRenderer.tsx
+++ b/src/PageRenderer.tsx
@@ -50,7 +50,9 @@ function PageRenderer({index, style, data}: Props) {
      */
     const pageHeight = calculatePageHeight(index);
     const devicePixelRatio = getDevicePixelRatio(pageWidth, pageHeight);
-    const topPadding = numPages > 1 ? parseFloat(style.top as unknown as string) + PAGE_BORDER : (containerHeight - parseFloat(style.height as unknown as string)) / 2;
+    const parsedHeight = parseFloat(style.height as unknown as string);
+    const parsedTop = parseFloat(style.top as unknown as string);
+    const topPadding = numPages > 1 || parsedHeight > containerHeight ? parsedTop + PAGE_BORDER : (containerHeight - parsedHeight) / 2;
     return (
         <div style={{...styles.pageWrapper, ...style, top: `${topPadding}px`}}>
             <Page


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Fixing the negative top padding in single-page PDFs that fill the entire page.







<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues


<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/react-fast-pdf/pull/16#issuecomment-2051021535

### Manual Tests
1. Upload two single-page PDFs: one with a long page and another with a short page.
2. Click on the PDF preview to open each document.
3. Ensure that both PDFs are centered properly. Check that the longer PDF displays correctly without the top padding being chopped off.







<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

### POC 

<img width="346" alt="Screenshot 2024-04-12 at 7 35 00 AM" src="https://github.com/Expensify/react-fast-pdf/assets/59809993/e84e3efb-1cfd-43e6-a052-a7f5f5a3214e">
<img width="1496" alt="Screenshot 2024-04-12 at 7 35 16 AM" src="https://github.com/Expensify/react-fast-pdf/assets/59809993/f80b115c-4003-4781-806b-ee11b734da51">

<img width="1494" alt="Screenshot 2024-04-12 at 7 40 27 AM" src="https://github.com/Expensify/react-fast-pdf/assets/59809993/cd841f23-1215-49d7-86d4-f8e46cd2c22a">


<img width="344" alt="image" src="https://github.com/Expensify/react-fast-pdf/assets/59809993/fbc268a3-a900-4ccf-84f9-1b9833808078">

