### PR TITLE
Only run CLA on `opened` and `synchronize` to fix race condition

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize]
 
 jobs:
   CLA:


### PR DESCRIPTION
### Details
Adjusts when we run the CLA workflow in order to prevent a race condition with our other bot checks.

### Related Issues
Fixes https://github.com/Expensify/Expensify/issues/438820