### PR TITLE
Update pdfWorkerSource to fix console warnings

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
             // This causes issues if we have gone offline before the pdfjs web worker is set up as we won't be able to load it from the server.
             {
                 // eslint-disable-next-line prefer-regex-literals
-                test: new RegExp('node_modules/pdfjs-dist/legacy/build/pdf.worker.js'),
+                test: new RegExp('node_modules/pdfjs-dist/legacy/build/pdf.worker.min.mjs'),
                 type: 'asset/source',
             },
         ],

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -1,6 +1,6 @@
 // @ts-expect-error - This line imports a module from 'pdfjs-dist' package which lacks TypeScript typings.
 // eslint-disable-next-line import/extensions
-import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker.mjs';
+import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs';
 import React, {memo, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import type {CSSProperties, ReactNode} from 'react';
 import times from 'lodash/times';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes two things:
1) Updates the worker path inside the webpack config of the example app, cause it used the non-existing file. Due to this the fake worker always was used.

![image](https://github.com/user-attachments/assets/aa8fc697-cf65-4a63-a2c5-036c37f5a744)

2) Uses a `pdf.worker.min.mjs` instead of `pdf.worker.js` to fix console warnings during PDF file preview.


### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/51313

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1) Launch the example app.
2) Open example PDF file.
3) Make sure there are no warnings in the console and file is displayed as expected.

![image](https://github.com/user-attachments/assets/55dcfaf8-84e8-4780-89da-026a1ed79acb)


### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/53080
