### PR TITLE
Update react-fast-pdf to use modern pdfjs-dist lib

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
             // This causes issues if we have gone offline before the pdfjs web worker is set up as we won't be able to load it from the server.
             {
                 // eslint-disable-next-line prefer-regex-literals
-                test: new RegExp('node_modules/pdfjs-dist/legacy/build/pdf.worker.min.mjs'),
+                test: new RegExp('node_modules/pdfjs-dist/build/pdf.worker.min.mjs'),
                 type: 'asset/source',
             },
         ],

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -1,6 +1,6 @@
 // @ts-expect-error - This line imports a module from 'pdfjs-dist' package which lacks TypeScript typings.
 // eslint-disable-next-line import/extensions
-import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs';
+import pdfWorkerSource from 'pdfjs-dist/build/pdf.worker.min.mjs';
 import React, {memo, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import type {CSSProperties, ReactNode} from 'react';
 import times from 'lodash/times';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

In the PR we want to load only the modern version of `pdf.worker.js` from `pdfjs-dist`, it allows to use new features and perf optimisations technics. 

slack discussion -> https://callstack-hq.slack.com/archives/C05LX9D6E07/p1734018797851159?thread_ts=1734018163.878969&cid=C05LX9D6E07


### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/54095

### Manual Tests
- Open the example app.
- Open example PDF file.
- Make sure that the file is displayed and are no warnings in the console

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
https://github.com/Expensify/App/pull/54250

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
