### PR TITLE
Use legacy worker for prev. IOS

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
             // This causes issues if we have gone offline before the pdfjs web worker is set up as we won't be able to load it from the server.
             {
                 // eslint-disable-next-line prefer-regex-literals
-                test: new RegExp('node_modules/pdfjs-dist/build/pdf.worker.min.mjs'),
+                test: new RegExp('node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'),
                 type: 'asset/source',
             },
         ],

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -1,6 +1,6 @@
 // @ts-expect-error - This line imports a module from 'pdfjs-dist' package which lacks TypeScript typings.
 // eslint-disable-next-line import/extensions
-import pdfWorkerSource from 'pdfjs-dist/build/pdf.worker.min.mjs';
+import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker.mjs';
 import React, {memo, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import type {CSSProperties, ReactNode} from 'react';
 import times from 'lodash/times';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

A bug was detected in the previous IOS version - `17.x`. Unfortunately, the latest PDF.js worker does not render files. I am returning the legacy one. 

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/55176

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Launch the example app.
2. Open an example PDF file.
3. Verify that there are no warnings in the console and that the file is displayed properly.

<details><summary>Screenshots</summary>
<p>

<img width="911" alt="legacy" src="https://github.com/user-attachments/assets/d38ef086-13de-4984-b364-b57aa37e9b4d" />


</p>
</details> 

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

Revert - https://github.com/Expensify/react-fast-pdf/pull/39, https://github.com/Expensify/react-fast-pdf/pull/40
