### PR TITLE
Import both PDF.js workers and apply legacy for prev. IOS

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -46,6 +46,11 @@ module.exports = {
             // This causes issues if we have gone offline before the pdfjs web worker is set up as we won't be able to load it from the server.
             {
                 // eslint-disable-next-line prefer-regex-literals
+                test: new RegExp('node_modules/pdfjs-dist/build/pdf.worker.min.mjs'),
+                type: 'asset/source',
+            },
+            {
+                // eslint-disable-next-line prefer-regex-literals
                 test: new RegExp('node_modules/pdfjs-dist/legacy/build/pdf.worker.min.mjs'),
                 type: 'asset/source',
             },

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -1,6 +1,7 @@
-// @ts-expect-error - This line imports a module from 'pdfjs-dist' package which lacks TypeScript typings.
 // eslint-disable-next-line import/extensions
-import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker.mjs';
+import pdfWorkerSource from 'pdfjs-dist/build/pdf.worker.min.mjs';
+// eslint-disable-next-line import/extensions
+import pdfWorkerLegacySource from 'pdfjs-dist/legacy/build/pdf.worker.mjs';
 import React, {memo, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import type {CSSProperties, ReactNode} from 'react';
 import times from 'lodash/times';
@@ -14,7 +15,7 @@ import {pdfPreviewerStyles as styles} from './styles';
 import PDFPasswordForm, {type PDFPasswordFormProps} from './PDFPasswordForm';
 import PageRenderer from './PageRenderer';
 import {PAGE_BORDER, LARGE_SCREEN_SIDE_SPACING, DEFAULT_DOCUMENT_OPTIONS, DEFAULT_EXTERNAL_LINK_TARGET, PDF_PASSWORD_FORM_RESPONSES} from './constants';
-import {setListAttributes} from './helpers';
+import {isMobileSafari, isModernSafari, setListAttributes} from './helpers';
 
 type Props = {
     file: string;
@@ -34,7 +35,15 @@ type Props = {
 
 type OnPasswordCallback = (password: string | null) => void;
 
-pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(new Blob([pdfWorkerSource], {type: 'text/javascript'}));
+const shouldUseLegacyWorker = isMobileSafari() && !isModernSafari();
+const pdfWorker: unknown = shouldUseLegacyWorker ? pdfWorkerLegacySource : pdfWorkerSource;
+
+console.log('[dev] isMobileSafari', isMobileSafari());
+console.log('[dev] isModernSafari', isModernSafari());
+console.log('[dev] shouldUseLegacyWorker', shouldUseLegacyWorker);
+console.log('[dev] pdfWorker', pdfWorker);
+
+pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(new Blob([pdfWorkerLegacySource], {type: 'text/javascript'}));
 
 const DefaultLoadingComponent = <p>Loading...</p>;
 const DefaultErrorComponent = <p>Failed to load the PDF file :(</p>;

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -36,14 +36,10 @@ type Props = {
 type OnPasswordCallback = (password: string | null) => void;
 
 const shouldUseLegacyWorker = isMobileSafari() && !isModernSafari();
-const pdfWorker: unknown = shouldUseLegacyWorker ? pdfWorkerLegacySource : pdfWorkerSource;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const pdfWorker = shouldUseLegacyWorker ? pdfWorkerLegacySource : pdfWorkerSource;
 
-console.log('[dev] isMobileSafari', isMobileSafari());
-console.log('[dev] isModernSafari', isModernSafari());
-console.log('[dev] shouldUseLegacyWorker', shouldUseLegacyWorker);
-console.log('[dev] pdfWorker', pdfWorker);
-
-pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(new Blob([pdfWorkerLegacySource], {type: 'text/javascript'}));
+pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(new Blob([pdfWorker], {type: 'text/javascript'}));
 
 const DefaultLoadingComponent = <p>Loading...</p>;
 const DefaultErrorComponent = <p>Failed to load the PDF file :(</p>;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -39,6 +39,13 @@ const isMobileSafari = (): boolean => {
 
 const isSafari = () => getBrowser() === 'safari' || isMobileSafari();
 
+const isModernSafari = (): boolean => {
+    const version = navigator.userAgent.match(/OS (\d+_\d+)/);
+    const iosVersion = version ? version[1].replace('_', '.') : '';
+
+    return parseFloat(iosVersion) >= 18;
+};
+
 type ListRef = {
     tabIndex: number;
 };
@@ -60,4 +67,4 @@ const setListAttributes = (ref: ListRef | undefined) => {
     ref.tabIndex = -1;
 };
 
-export {getBrowser, isMobileSafari, isSafari, setListAttributes};
+export {getBrowser, isMobileSafari, isSafari, isModernSafari, setListAttributes};

--- a/src/pdf.worker.d.ts
+++ b/src/pdf.worker.d.ts
@@ -1,0 +1,2 @@
+declare module 'pdfjs-dist/build/pdf.worker.min.mjs';
+declare module 'pdfjs-dist/legacy/build/pdf.worker.mjs';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

Import both PDF.js workers and apply the legacy version for previous iOS versions by obtaining the iOS version. If the user’s age is less than 18, use legacy code; otherwise, use modern code.

<details><summary>Screenshots</summary>
<p>

<img width="1356" alt="Screenshot 2025-02-03 at 17 11 17" src="https://github.com/user-attachments/assets/cc50f17c-9c41-4930-93f1-1928c7866509" />
<img width="1919" alt="Screenshot 2025-02-03 at 17 11 29" src="https://github.com/user-attachments/assets/df682267-6adc-4d14-8c93-de4d6ff6c694" />
<img width="1915" alt="Screenshot 2025-02-03 at 17 11 37" src="https://github.com/user-attachments/assets/d4374e5d-962c-4d63-b79c-d56053994789" />

</p>
</details> 

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/55176

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Launch the example app (_especially IOS 17.x_).
2. Open an example PDF file.
3. Verify that there are no warnings in the console and that the file is displayed properly.

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
