### PR TITLE
fix: apply resizing fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 
 # NPM file created by GitHub actions
 .npmrc
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fast-pdf",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "react-fast-pdf",
   "main": "./dist/index.js",
   "files": [

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -67,11 +67,12 @@ function PDFPreviewer({
     const [isPasswordInvalid, setIsPasswordInvalid] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
     const onPasswordCallbackRef = useRef<OnPasswordCallback | null>(null);
+    const listRef = useRef<List>(null);
 
     /**
      * Calculate the devicePixelRatio the page should be rendered with
      * Each platform has a different default devicePixelRatio and different canvas limits, we need to verify that
-     * with the default devicePixelRatio it will be able to diplay the pdf correctly, if not we must change the devicePixelRatio.
+     * with the default devicePixelRatio it will be able to display the pdf correctly, if not we must change the devicePixelRatio.
      * @param {Number} width of the page
      * @param {Number} height of the page
      * @returns {Number} devicePixelRatio for this page on this platform
@@ -206,6 +207,15 @@ function PDFPreviewer({
         );
     }, [isPasswordInvalid, attemptPDFLoad, setIsPasswordInvalid, renderPasswordForm]);
 
+    /**
+     * Reset List style cache when dimensions change
+     */
+    useLayoutEffect(() => {
+        if (containerWidth > 0 && containerHeight > 0) {
+            listRef.current?.resetAfterIndex(0);
+        }
+    }, [containerWidth, containerHeight]);
+
     useLayoutEffect(() => {
         if (!containerRef.current) {
             return undefined;
@@ -240,6 +250,7 @@ function PDFPreviewer({
                 >
                     {pageViewports.length > 0 && (
                         <List
+                            ref={listRef}
                             style={{...styles.list, ...contentContainerStyle}}
                             outerRef={setListAttributes}
                             width={isSmallScreen ? pageWidth : containerWidth}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

Implement cache invalidation using ⁠react-window's ⁠resetAfterIndex API and combining it with another useLayoutEffect in this component - to prevent `top` value miscalculation for the PageRenderer.

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/55941

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. In EApp (web/mWeb) go to an uploaded receipt.
2. Open the preview.
3. Verify that no blank space is rendered above the receipt.
4. Repeat a few times - verify that the receipt is always rendered correctly.
5. Try to scroll down and resize the screen - there should be no problems with resizing and the scroll position.

https://github.com/user-attachments/assets/b76f1115-f5ad-4ca6-bc68-a2144288a54c


### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
