### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/style_and_syntax_checks.yml
+++ b/.github/workflows/style_and_syntax_checks.yml
@@ -9,10 +9,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              # v3
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              # v3
+              uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7
               with:
                   node-version: 18
                   cache: npm


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/CC7NECV4L/p1743022578963949, this pull request updates all mutable action references to use immutable commit hashes instead. This is a security measure to protect from supply chain attacks.