### PR TITLE
Move responsibility for configuring PDF worker to the consumer

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -43,6 +43,9 @@
                 "webpack": "^5.104.1",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "^4.15.1"
+            },
+            "peerDependencies": {
+                "pdfjs-dist": "^4.x || ^5.x"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/example/package.json
+++ b/example/package.json
@@ -35,6 +35,9 @@
         "react-dom": "^18.2.0",
         "react-fast-pdf": "^1.0.23"
     },
+    "peerDependencies": {
+        "pdfjs-dist": "^4.x || ^5.x"
+    },
     "devDependencies": {
         "@babel/cli": "^7.22.9",
         "@babel/core": "^7.22.9",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,10 @@
 import React, {useState} from 'react';
+import pdfWorkerSource from 'pdfjs-dist/build/pdf.worker.min.mjs';
+import * as pdfjs from 'pdfjs-dist';
 import ReactFastPDF, {PDFPreviewer} from 'react-fast-pdf';
 import './index.css';
+
+pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(new Blob([pdfWorkerSource], {type: 'text/javascript'}));
 
 function App() {
     const [file, setFile] = useState<string | null>(null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
       },
       "peerDependencies": {
         "lodash": "4.x",
-        "pdfjs-dist": "5.4.296",
         "react": "18.x",
         "react-dom": "18.x"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "peerDependencies": {
     "lodash": "4.x",
-    "pdfjs-dist": "5.4.296",
     "react": "18.x",
     "react-dom": "18.x"
   },

--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -1,9 +1,8 @@
-import pdfWorkerSource from 'pdfjs-dist/build/pdf.worker.min.mjs';
 import React, {memo, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import type {CSSProperties, ReactNode} from 'react';
 import times from 'lodash/times.js';
 import {VariableSizeList as List} from 'react-window';
-import {Document, pdfjs} from 'react-pdf';
+import {Document} from 'react-pdf';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
@@ -31,8 +30,6 @@ type Props = {
 };
 
 type OnPasswordCallback = (password: string | null) => void;
-
-pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(new Blob([pdfWorkerSource], {type: 'text/javascript'}));
 
 const DefaultLoadingComponent = <p>Loading...</p>;
 const DefaultErrorComponent = <p>Failed to load the PDF file :(</p>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
+import {pdfjs} from 'react-pdf';
 import PDFPreviewer from './PDFPreviewer.js';
 
 const PACKAGE_NAME = 'react-fast-pdf';
 
-export {PDFPreviewer};
+export {PDFPreviewer, pdfjs};
 
 export default {
     PackageName: PACKAGE_NAME,

--- a/src/pdf.worker.d.ts
+++ b/src/pdf.worker.d.ts
@@ -1,1 +1,0 @@
-declare module 'pdfjs-dist/build/pdf.worker.min.mjs';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

We have switched between the modern and legacy PDF worker multiple times in the past. Each time we do this, we must update both E/App and this repo. PR https://github.com/Expensify/react-fast-pdf/pull/45 and https://github.com/Expensify/App/pull/56473 are good examples of how we had to implement the same code twice, only to remove it later (again in both repos).

Furthermore, setting `pdfjs.GlobalWorkerOptions.workerSrc` in E/App has no effect because it would get overridden by this line:

https://github.com/Expensify/react-fast-pdf/blob/0388690a4d084231069bded84dadf10ba063de7f/src/PDFPreviewer.tsx#L35

Even with the correct import order, both worker builds would be included in the bundle, increasing its size.

This PR removes the default worker configuration and instead expects applications using this library to configure it, which is the same approach used by `react-pdf`. This makes it more reliable and easier to maintain (we will only need to update the worker once in E/App).

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/76303

### Manual Tests

1. Build with `npm run build && npm pack`.
2. Install it in the example app or E/App with `npm install ../react-fast-pdf-1.0.31.tgz`.
3. Open a PDF file.
4. Verify that the file is displayed properly.


### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
