### PR TITLE
Allow overriding document options via `options` prop

### DIFF
--- a/src/PDFPreviewer.tsx
+++ b/src/PDFPreviewer.tsx
@@ -3,6 +3,7 @@ import type {CSSProperties, ReactNode} from 'react';
 import times from 'lodash/times.js';
 import {VariableSizeList as List} from 'react-window';
 import {Document} from 'react-pdf';
+import type {DocumentProps} from 'react-pdf';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
@@ -28,6 +29,7 @@ type Props = {
     containerStyle?: CSSProperties;
     contentContainerStyle?: CSSProperties;
     rotation?: RotationDegrees;
+    options?: DocumentProps['options'];
 };
 
 type OnPasswordCallback = (password: string | null) => void;
@@ -50,6 +52,7 @@ function PDFPreviewer({
     shouldShowErrorComponent = true,
     onLoadError,
     rotation = 0,
+    options = DEFAULT_DOCUMENT_OPTIONS,
 }: Props): JSX.Element {
     const [pageViewports, setPageViewports] = useState<PageViewport[]>([]);
     const [numPages, setNumPages] = useState(0);
@@ -252,7 +255,7 @@ function PDFPreviewer({
             >
                 <Document
                     file={file}
-                    options={DEFAULT_DOCUMENT_OPTIONS}
+                    options={options}
                     externalLinkTarget={DEFAULT_EXTERNAL_LINK_TARGET}
                     error={shouldShowErrorComponent ? ErrorComponent : null}
                     onLoadError={onLoadError}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,7 @@ const LARGE_SCREEN_SIDE_SPACING = 40;
  * 2. cMapPacked - specifies if the Adobe CMaps are binary packed or not. The default value is `true`.
  */
 const DEFAULT_DOCUMENT_OPTIONS = {
-    cMapUrl: 'cmaps/',
+    cMapUrl: '/cmaps/',
     cMapPacked: true,
 };
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

- Add an optional `options` prop (typed as `DocumentProps['options']`)  that defaults to `DEFAULT_DOCUMENT_OPTIONS` and is forwarded to `<Document>`. This way, this prop can be overridden by consimer.
- Update `DEFAULT_DOCUMENT_OPTIONS.cMapUrl` to `/cmaps/`. Reason explained here: https://github.com/Expensify/App/issues/94484#issuecomment-4798240184

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/94484

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

N/A

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/94568
